### PR TITLE
Enable better brightness control and general tidy up

### DIFF
--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "pxt-kitronik-zip-64",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "description": "Blocks for driving the Kitronik :GAME ZIP64",
     "license": "MIT",
     "dependencies": {

--- a/pxt.json
+++ b/pxt.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "dependencies": {
         "core": "*",
-        "ws2812b": "github:Microsoft/pxt-ws2812b#v0.0.4"
+        "ws2812b": "github:KitronikLtd/pxt-ws2812b#v0.0.5"
     },
     "files": [
         "README.md",

--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "pxt-kitronik-zip-64",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "description": "Blocks for driving the Kitronik :GAME ZIP64",
     "license": "MIT",
     "dependencies": {

--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "pxt-kitronik-zip-64",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "description": "Blocks for driving the Kitronik :GAME ZIP64",
     "license": "MIT",
     "dependencies": {

--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "pxt-kitronik-zip-64",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "Blocks for driving the Kitronik :GAME ZIP64",
     "license": "MIT",
     "dependencies": {

--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "pxt-kitronik-zip-64",
-    "version": "0.0.10",
+    "version": "0.0.11",
     "description": "Blocks for driving the Kitronik :GAME ZIP64",
     "license": "MIT",
     "dependencies": {

--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "pxt-kitronik-zip-64",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "description": "Blocks for driving the Kitronik :GAME ZIP64",
     "license": "MIT",
     "dependencies": {

--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "pxt-kitronik-zip-64",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "description": "Blocks for driving the Kitronik :GAME ZIP64",
     "license": "MIT",
     "dependencies": {

--- a/zip64.ts
+++ b/zip64.ts
@@ -238,7 +238,7 @@ namespace GAME_ZIP64 {
          * @param rgb RGB color of the LED
          */
         //% group=Display
-        //% blockId="zip64_display_set_matrix_color" block="%string|set matrix color at x %x|y %y|to %rgb=zip_colors" 
+        //% blockId="zip64_display_set_matrix_color" block="%display|set matrix color at x %x|y %y|to %rgb=zip_colors" 
         //% weight=99
         setMatrixColor(x: number, y: number, rgb: number) {
             const cols = this._length / this._matrixWidth;
@@ -344,6 +344,7 @@ namespace GAME_ZIP64 {
     //% blockId="zip64_display_create" block="ZIP64 8x8 matrix display"
     //% weight=100 blockGap=8
     //% trackArgs=0,2
+    //% blockSetVariable=display
     export function createZIP64Display(): ZIP64Display {
         let display = new ZIP64Display();
         display.buf = pins.createBuffer(64 * 3);

--- a/zip64.ts
+++ b/zip64.ts
@@ -405,7 +405,7 @@ namespace GAME_ZIP64 {
         let stride = 0 === ZipLedMode.RGBW ? 4 : 3;
         display.buf = pins.createBuffer(64 * stride);
         display.start = 0;
-        display._length = 65;
+        display._length = 64;
         display._mode = 0;
         display._matrixWidth = 8;
         display.setBrightness(255)

--- a/zip64.ts
+++ b/zip64.ts
@@ -271,7 +271,7 @@ namespace GAME_ZIP64 {
         //% blockId="zip64_display_show" block="%display|show" blockGap=8
         //% weight=97
         show() {
-            ws2812b.sendBuffer(this.buf, this.pin);
+            ws2812b.sendBuffer(this.buf, this.pin, this.brightness);
         }
 
         /**

--- a/zip64.ts
+++ b/zip64.ts
@@ -32,18 +32,6 @@ namespace GAME_ZIP64 {
 //This is the :GAME ZIP64 Package
 
 	/**
-	 * Different modes for RGB or RGB+W ZIP strips
-	 */
-	export enum ZipLedMode {
-	    //% block="RGB (GRB format)"
-	    RGB = 0,
-	    //% block="RGB+W"
-	    RGBW = 1,
-	    //% block="RGB (RGB format)"
-	    RGB_RGB = 2
-	}
-
-	/**
 	*:GAME ZIP64 Standard Buttons
 	*/
 	export enum ZIP64Buttons {
@@ -150,7 +138,6 @@ namespace GAME_ZIP64 {
     	brightness: number;
     	start: number;
     	_length: number;
-    	_mode: ZipLedMode;
     	_matrixWidth: number;
 
         /**
@@ -227,8 +214,7 @@ namespace GAME_ZIP64 {
         //% blockId="zip64display_rotate" block="%display|rotate ZIP LEDs by %offset" blockGap=8
         //% weight=50
         rotate(offset: number = 1): void {
-            const stride = this._mode === ZipLedMode.RGBW ? 4 : 3;
-            this.buf.rotate(-offset * stride, this.start * stride, this._length * stride)
+            this.buf.rotate(-offset * 3, this.start * 3, this._length * 3)
         }
 
     	/**
@@ -282,8 +268,7 @@ namespace GAME_ZIP64 {
         //% blockId="zip64_display_clear" block="%display|clear"
         //% weight=96
         clear(): void {
-            const stride = this._mode === ZipLedMode.RGBW ? 4 : 3;
-            this.buf.fill(0, this.start * stride, this._length * stride);
+            this.buf.fill(0, this.start * 3, this._length * 3);
         }
 
         /**
@@ -322,13 +307,8 @@ namespace GAME_ZIP64 {
         }
 
         private setBufferRGB(offset: number, red: number, green: number, blue: number): void {
-            if (this._mode === ZipLedMode.RGB_RGB) {
-                this.buf[offset + 0] = red;
-                this.buf[offset + 1] = green;
-            } else {
-                this.buf[offset + 0] = green;
-                this.buf[offset + 1] = red;
-            }
+            this.buf[offset + 0] = green;
+            this.buf[offset + 1] = red;
             this.buf[offset + 2] = blue;
         }
 
@@ -338,20 +318,8 @@ namespace GAME_ZIP64 {
             let blue = unpackB(rgb);
 
             const end = this.start + this._length;
-            const stride = this._mode === ZipLedMode.RGBW ? 4 : 3;
             for (let i = this.start; i < end; ++i) {
-                this.setBufferRGB(i * stride, red, green, blue)
-            }
-        }
-        private setAllW(white: number) {
-            if (this._mode !== ZipLedMode.RGBW)
-                return;
-
-            let buf = this.buf;
-            let end = this.start + this._length;
-            for (let i = this.start; i < end; ++i) {
-                let ledoffset = i * 4;
-                buf[ledoffset + 3] = white;
+                this.setBufferRGB(i * 3, red, green, blue)
             }
         }
         private setPixelRGB(pixeloffset: number, rgb: number): void {
@@ -359,27 +327,13 @@ namespace GAME_ZIP64 {
                 || pixeloffset >= this._length)
                 return;
 
-            let stride = this._mode === ZipLedMode.RGBW ? 4 : 3;
-            pixeloffset = (pixeloffset + this.start) * stride;
+            pixeloffset = (pixeloffset + this.start) * 3;
 
             let red = unpackR(rgb);
             let green = unpackG(rgb);
             let blue = unpackB(rgb);
 
             this.setBufferRGB(pixeloffset, red, green, blue)
-        }
-        private setPixelW(pixeloffset: number, white: number): void {
-            if (this._mode !== ZipLedMode.RGBW)
-                return;
-
-            if (pixeloffset < 0
-                || pixeloffset >= this._length)
-                return;
-
-            pixeloffset = (pixeloffset + this.start) * 4;
-
-            let buf = this.buf;
-            buf[pixeloffset + 3] = white;
         }
     }
 
@@ -392,11 +346,9 @@ namespace GAME_ZIP64 {
     //% trackArgs=0,2
     export function createZIP64Display(): ZIP64Display {
         let display = new ZIP64Display();
-        let stride = 0 === ZipLedMode.RGBW ? 4 : 3;
-        display.buf = pins.createBuffer(64 * stride);
+        display.buf = pins.createBuffer(64 * 3);
         display.start = 0;
         display._length = 64;
-        display._mode = 0;
         display._matrixWidth = 8;
         display.setBrightness(255)
         display.setPin(DigitalPin.P0)

--- a/zip64.ts
+++ b/zip64.ts
@@ -405,7 +405,7 @@ namespace GAME_ZIP64 {
         let stride = 0 === ZipLedMode.RGBW ? 4 : 3;
         display.buf = pins.createBuffer(64 * stride);
         display.start = 0;
-        display._length = 64;
+        display._length = 65;
         display._mode = 0;
         display._matrixWidth = 8;
         display.setBrightness(255)

--- a/zip64.ts
+++ b/zip64.ts
@@ -337,12 +337,6 @@ namespace GAME_ZIP64 {
             let green = unpackG(rgb);
             let blue = unpackB(rgb);
 
-            const br = this.brightness;
-            if (br < 255) {
-                red = (red * br) >> 8;
-                green = (green * br) >> 8;
-                blue = (blue * br) >> 8;
-            }
             const end = this.start + this._length;
             const stride = this._mode === ZipLedMode.RGBW ? 4 : 3;
             for (let i = this.start; i < end; ++i) {
@@ -353,10 +347,6 @@ namespace GAME_ZIP64 {
             if (this._mode !== ZipLedMode.RGBW)
                 return;
 
-            let br = this.brightness;
-            if (br < 255) {
-                white = (white * br) >> 8;
-            }
             let buf = this.buf;
             let end = this.start + this._length;
             for (let i = this.start; i < end; ++i) {
@@ -376,12 +366,6 @@ namespace GAME_ZIP64 {
             let green = unpackG(rgb);
             let blue = unpackB(rgb);
 
-            let br = this.brightness;
-            if (br < 255) {
-                red = (red * br) >> 8;
-                green = (green * br) >> 8;
-                blue = (blue * br) >> 8;
-            }
             this.setBufferRGB(pixeloffset, red, green, blue)
         }
         private setPixelW(pixeloffset: number, white: number): void {
@@ -394,10 +378,6 @@ namespace GAME_ZIP64 {
 
             pixeloffset = (pixeloffset + this.start) * 4;
 
-            let br = this.brightness;
-            if (br < 255) {
-                white = (white * br) >> 8;
-            }
             let buf = this.buf;
             buf[pixeloffset + 3] = white;
         }

--- a/zip64.ts
+++ b/zip64.ts
@@ -294,7 +294,17 @@ namespace GAME_ZIP64 {
         //% blockId="zip64_display_set_brightness" block="%display|set brightness %brightness" blockGap=8
         //% weight=95
         setBrightness(brightness: number): void {
+            //Clamp incoming variable at 0-255 Math.clamp didnt work...
+            if(brightness <0)
+            {
+              brightness = 0
+            }
+            else if (brightness > 255)
+            {
+              brightness = 255
+            }
             this.brightness = brightness & 0xff;
+            basic.pause(1) //add a pause to stop weirdnesses
         }
 
         /**


### PR DESCRIPTION
Changed to using KitronikLtd WS2812B driver.
Creating a new ZIP64 display now auto creates a variable (in the block definition).
Removed some unnecessary code relating to RGBW LEDs.